### PR TITLE
Android soong buildsystem file

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,15 @@
+/*
+ * Universal AOSP build file
+ * Available both in system and vendor
+ */
+cc_library_headers {
+    name: "librlib_embeeded_basics",
+
+    export_include_dirs: [
+        "rlib/include",
+    ],
+
+    host_supported: true,
+    vendor_available: true
+}
+


### PR DESCRIPTION
Added android buildsystem file.
Target name made longer then in CMakeLists.txt
because of less chance of conflict.