### PR TITLE
Update soong library target to be available in recovery. Fix typos.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3,13 +3,14 @@
  * Available both in system and vendor
  */
 cc_library_headers {
-    name: "librlib_embeeded_basics",
+    name: "librlib_embedded_basics",
 
     export_include_dirs: [
         "rlib/include",
     ],
 
     host_supported: true,
-    vendor_available: true
+    recovery_available: true,
+    vendor_available: true,
 }
 


### PR DESCRIPTION
Add possibility to use librlib_embedded_basics in android-recovery. Fix library name to match project name.